### PR TITLE
print last commit in footer

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "predeploy": "yarn build",
     "deploy": "gh-pages -d build",
     "start": "craco start",
-    "build": "craco build",
+    "build": "REACT_APP_GIT_SHA=`git rev-parse --short HEAD` REACT_APP_GIT_DATE=`git log -1 --date=format:\"%Y/%m/%d\" --format=\"%ad\"` craco build",
     "test": "craco test",
     "eject": "react-scripts eject"
   },

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -15,6 +15,11 @@ const footerElements = [
   { description: 'GitHub', link: helpUrls.github },
   { description: 'Project Serum', link: helpUrls.projectSerum },
   { description: 'Solana Network', link: helpUrls.solanaBeach },
+  {
+    description: `DEX UI V-${process.env.REACT_APP_GIT_SHA} (${process.env.REACT_APP_GIT_DATE})`,
+    link:
+      helpUrls.github + '/serum-dex-ui/commit/' + process.env.REACT_APP_GIT_SHA,
+  },
 ];
 
 export const CustomFooter = () => {


### PR DESCRIPTION
On build print the latest git commit with it's date in the footer, with a link to the github commit:

<img width="929" alt="Screenshot 2020-09-15 at 01 16 38" src="https://user-images.githubusercontent.com/969743/93117457-78a74200-f6f1-11ea-8d38-69fb287c8a7b.png">

Note: this works on unix/linux, no clue about windows!

Feel free to merge or not, regardless I'll be using this on: https://serum-mirror.folkvang.io/