### PR TITLE
Add support for Solong wallet extension

### DIFF
--- a/src/utils/solong_adapter.tsx
+++ b/src/utils/solong_adapter.tsx
@@ -1,0 +1,63 @@
+import EventEmitter from 'eventemitter3';
+import { PublicKey } from '@solana/web3.js';
+import { notify } from "./notifications";
+
+export class SolongAdapter extends EventEmitter {
+  _publicKey: any
+  _onProcess:boolean
+  constructor(providerUrl: string, network: string) {
+    super()
+    this._publicKey = null;
+    this._onProcess = false;
+    this.connect= this.connect.bind(this);
+    this.disconnect= this.disconnect.bind(this);
+  }
+
+  get publicKey() {
+    return this._publicKey;
+  }
+
+  async signTransaction(transaction: any) {
+    const trx  = await  (window as any).solong.signTransaction(transaction).catch(
+      () => {
+        throw {message:"Reject sign request!"}
+      }
+    );
+    return trx
+  }
+
+  connect() {
+    if (this._onProcess) {
+      return ;
+    }
+
+    if ((window as any).solong === undefined){
+      notify({
+        message: "Solong Error",
+        description: "Please install solong wallet from Chrome " ,
+      });
+      return;
+    }
+
+    this._onProcess = true;
+    console.log('solong helper select account');
+    (window as any).solong
+      .selectAccount()
+      .then((account: any) => {
+        this._publicKey = new PublicKey(account);
+        console.log('window solong select:', account, 'this:', this);
+        this.emit('connect', this._publicKey);
+      })
+      .catch(() => {
+        this.disconnect()
+      })
+      .finally(()=>{this._onProcess=false});
+  }
+
+  disconnect (){
+    if (this._publicKey) {
+      this._publicKey = null;
+      this.emit('disconnect');
+    }
+  }
+}

--- a/src/utils/wallet.tsx
+++ b/src/utils/wallet.tsx
@@ -4,8 +4,10 @@ import { notify } from './notifications';
 import { useConnectionConfig } from './connection';
 import { useLocalStorageState } from './utils';
 import { WalletContextValues } from './types';
+import {SolongAdapter} from './solong_adapter'
 
 export const WALLET_PROVIDERS = [
+  {name:'solong', url:'https://solongwallet.com/'},
   { name: 'sollet.io', url: 'https://www.sollet.io' },
 ];
 
@@ -25,7 +27,12 @@ export function WalletProvider({ children }) {
     providerUrl = savedProviderUrl;
   }
 
-  const wallet = useMemo(() => new Wallet(providerUrl, endpoint), [
+  const wallet :any = useMemo(() => { 
+    if (providerUrl === 'https://solongwallet.com/') { 
+      return new SolongAdapter(providerUrl, endpoint);
+    } else {
+      return new Wallet(providerUrl, endpoint)
+    }}, [
     providerUrl,
     endpoint,
   ]);


### PR DESCRIPTION
The [SolongWallet Chrome Extension](http://solongwallet.com/) has already publish on [Chome extension store](https://chrome.google.com/webstore/category/extensions).

And we add SolongAdapter which works like [sol-wallet-adapter](https://github.com/project-serum/sol-wallet-adapter)
to support Dapps which already use [sol-wallet-adapter](https://github.com/project-serum/sol-wallet-adapter)