### PR TITLE
dfuse serum instruction history

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@ant-design/icons": "^4.2.1",
     "@craco/craco": "^5.6.4",
+    "@dfuse/client": "^0.3.17",
     "@project-serum/awesome-serum": "1.0.1",
     "@project-serum/pool": "^0.1.1",
     "@project-serum/serum": "^0.13.11",

--- a/src/components/UserInfoTable/InstructionTable.tsx
+++ b/src/components/UserInfoTable/InstructionTable.tsx
@@ -1,0 +1,263 @@
+import React from 'react';
+import DataTable from '../layout/DataTable';
+import { useWallet } from '../../utils/wallet';
+import { Col, Row, Tag } from 'antd';
+import { Account, Instruction, useSerumInstruction } from './dfuse/use-serum-instruction';
+import { MarketInfo } from '../../utils/types';
+import { MARKETS } from '@project-serum/serum';
+
+// Used in debugging, should be false in production
+const _IGNORE_DEPRECATED = false;
+
+const USE_MARKETS: MarketInfo[] = _IGNORE_DEPRECATED
+  ? MARKETS.map((m) => ({ ...m, deprecated: false }))
+  : MARKETS;
+
+
+const resolveMarket = (marketAddress: string): string => {
+  let marketName = marketAddress;
+  USE_MARKETS.map(market => {
+    if (market.address.toString() == marketAddress) {
+      marketName = market.name;
+    }
+  });
+  return marketName;
+};
+
+const renderInstructionDetails = (instruction: Instruction) => {
+  switch (instruction.instruction.__typename) {
+    case 'SerumSettleFunds':
+      return (
+        <div>
+          <strong>No input data</strong>
+        </div>
+      );
+    case 'SerumNewOrder':
+      return (
+        <div>
+          <strong>Side:</strong> {instruction.instruction.side}<br />
+          <strong>Limit Price:</strong> {instruction.instruction.limitPrice}<br />
+          <strong>Max Quantity:</strong> {instruction.instruction.maxQuantity}<br />
+          <strong>Order Type:</strong> {instruction.instruction.orderType}<br />
+          <strong>Client Id:</strong> {instruction.instruction.clientID}<br />
+        </div>
+      );
+    case 'SerumMatchOrder':
+      return (
+        <div>
+          <strong>Limit:</strong> {instruction.instruction.limit}<br />
+        </div>
+      );
+    case 'SerumInitializeMarket':
+      return (
+        <div>
+          <strong>Base Lot Size:</strong> {instruction.instruction.baseLotSize}<br />
+          <strong>Quote Lot Size:</strong> {instruction.instruction.quoteLotSize}<br />
+          <strong>Fee Rate Bps:</strong> {instruction.instruction.feeRateBps}<br />
+          <strong>Vault Signer Nonce:</strong> {instruction.instruction.vaultSignerNonce}<br />
+          <strong>Quote Dust Threshold:</strong> {instruction.instruction.quoteLotSize}
+        </div>
+      );
+    case 'SerumConsumeEvents':
+      return (
+        <div>
+          <strong>Limit:</strong> {instruction.instruction.limit}<br />
+        </div>
+      );
+    case 'SerumCancelOrderByClientId':
+      return (
+        <div>
+          <strong>Client ID:</strong> {instruction.instruction.clientID}<br />
+        </div>
+      );
+    case 'SerumCancelOrder':
+      return (
+        <div>
+          <strong>Side: </strong> {instruction.instruction.side}<br />
+          <strong>Order Id: </strong> {instruction.instruction.orderId}<br />
+          <strong>Open Orders: </strong> {instruction.instruction.openOrders}<br />
+          <strong>Open Order Slot: </strong> {instruction.instruction.openOrderSlot}<br />
+        </div>
+      );
+  }
+
+};
+
+const renderAccount = (display: string, account: Account | undefined) => {
+  if (!account) {
+    return null;
+  }
+
+  return (
+    <><Col span={6}><strong>{display}</strong></Col>
+      <Col span={18}>
+        <code>{account.publicKey}</code>
+        {account.isWritable && <Tag color={'warning'} style={{ marginLeft: '10px' }}>Writable</Tag>}
+        {account.isSigner && <Tag color={'green'} style={{ marginLeft: '10px' }}>Signer</Tag>}
+      </Col>
+    </>
+  );
+};
+
+const renderInstructionAddresses = (instruction: Instruction) => {
+  switch (instruction.instruction.__typename) {
+    case 'SerumSettleFunds':
+      return (
+        <Row>
+          {renderAccount('Open Orders', instruction.instruction.accounts.openOrders)} <br />
+          {renderAccount('Owner', instruction.instruction.accounts.owner)} <br />
+          {renderAccount('Coin Vault', instruction.instruction.accounts.coinVault)} <br />
+          {renderAccount('PC Vault', instruction.instruction.accounts.pcVault)} <br />
+          {renderAccount('Coin Wallet', instruction.instruction.accounts.coinWallet)} <br />
+          {renderAccount('PC Wallet', instruction.instruction.accounts.pcWallet)} <br />
+          {renderAccount('Signer', instruction.instruction.accounts.signer)} <br />
+          {renderAccount('SPL Token Program', instruction.instruction.accounts.splTokenProgram)} <br />
+          {renderAccount('Referrer PC Wallet', instruction.instruction.accounts.referrerPCWallet)}
+        </Row>
+      );
+    case 'SerumNewOrder':
+      return (
+        <Row>
+          {renderAccount('Open Orders', instruction.instruction.accounts.openOrders)} <br />
+          {renderAccount('Request Queue', instruction.instruction.accounts.requestQueue)} <br />
+          {renderAccount('Payer', instruction.instruction.accounts.payer)} <br />
+          {renderAccount('Owner', instruction.instruction.accounts.owner)} <br />
+          {renderAccount('Coin Vault', instruction.instruction.accounts.coinVault)} <br />
+          {renderAccount('PC Vault', instruction.instruction.accounts.pcVault)} <br />
+          {renderAccount('SPL Token Program', instruction.instruction.accounts.splTokenProgram)} <br />
+          {renderAccount('Rent', instruction.instruction.accounts.rent)} <br />
+          {renderAccount('SRM Discount', instruction.instruction.accounts.srmDiscount)}
+        </Row>
+      );
+    case 'SerumMatchOrder':
+      return (
+        <Row>
+          {renderAccount('Request Queue', instruction.instruction.accounts.requestQueue)} <br />
+          {renderAccount('Event Queue', instruction.instruction.accounts.eventQueue)} <br />
+          {renderAccount('Bids', instruction.instruction.accounts.bids)} <br />
+          {renderAccount('Asks', instruction.instruction.accounts.asks)} <br />
+          {renderAccount('Coin Fee Receivable', instruction.instruction.accounts.coinFeeReceivable)} <br />
+          {renderAccount('PC Fee Receivable', instruction.instruction.accounts.pcFeeReceivable)} <br />
+        </Row>
+      );
+    case 'SerumInitializeMarket':
+      return (
+        <Row>
+          {renderAccount('SPL Coin Token', instruction.instruction.accounts.splCoinToken)} <br />
+          {renderAccount('SPL Price Token', instruction.instruction.accounts.splPriceToken)} <br />
+          {renderAccount('Coin Mint', instruction.instruction.accounts.coinMint)} <br />
+          {renderAccount('Price Mint', instruction.instruction.accounts.priceMint)} <br />
+        </Row>
+      );
+    case 'SerumConsumeEvents':
+      return (
+        <Row>
+          {renderAccount('Event Queue', instruction.instruction.accounts.eventQueue)} <br />
+          {renderAccount('Coin Fee Receivable', instruction.instruction.accounts.coinFeeReceivable)} <br />
+          {renderAccount('PC Fee Receivable', instruction.instruction.accounts.pcFeeReceivable)} <br />
+        </Row>);
+    case 'SerumCancelOrderByClientId':
+      return (
+        <Row>
+          {renderAccount('Open Orders', instruction.instruction.accounts.openOrders)} <br />
+          {renderAccount('Request Queue', instruction.instruction.accounts.requestQueue)} <br />
+          {renderAccount('Owner', instruction.instruction.accounts.owner)} <br />
+        </Row>
+      );
+    case 'SerumCancelOrder':
+      return (
+        <Row>
+          {renderAccount('Request Queue', instruction.instruction.accounts.requestQueue)} <br />
+          {renderAccount('Owner', instruction.instruction.accounts.owner)} <br />
+        </Row>
+      );
+  }
+
+};
+
+
+const columns = [
+  {
+    title: 'Instruction',
+    dataIndex: 'instruction',
+    key: 'instruction',
+    render: (_, instruction: Instruction) => {
+      switch (instruction.instruction.__typename) {
+        case 'SerumCancelOrder':
+          return 'Cancel Order';
+        case 'SerumCancelOrderByClientId':
+          return 'Cancel Order by Client Id';
+        case 'SerumConsumeEvents':
+          return 'Consume Events';
+        case 'SerumInitializeMarket':
+          return 'Initialize Market';
+        case 'SerumMatchOrder':
+          return 'Match Order';
+        case 'SerumNewOrder':
+          return 'New order';
+        case 'SerumSettleFunds':
+          return 'Settle Funds';
+      }
+      return 'Unknown';
+    },
+  },
+  {
+    title: 'Market',
+    dataIndex: 'market',
+    key: 'market',
+    render: (_, instruction: Instruction) => {
+      if (instruction.instruction?.accounts?.market) {
+        return resolveMarket(instruction.instruction.accounts.market.publicKey);
+      }
+      return 'n/a';
+    },
+  },
+  {
+    title: 'Details',
+    dataIndex: 'details',
+    key: 'details',
+    render: (_, instruction: Instruction) => {
+      return renderInstructionDetails(instruction);
+    },
+  }, {
+    title: 'Addresses',
+    dataIndex: 'addresses',
+    key: 'addresses',
+    width: 600,
+    render: (_, instruction: Instruction) => {
+      return renderInstructionAddresses(instruction);
+    },
+  }];
+
+export default function InstructionTable() {
+  let { wallet } = useWallet();
+
+
+  const publicKey = wallet.publicKey.toString();
+  const {
+    instructions,
+    isStreaming,
+  } = useSerumInstruction({
+    account: publicKey,
+  });
+
+
+  const dataSource = (instructions || []).map((instruction, index) => ({
+    ...instruction,
+    key: `${index}`,
+  }));
+
+
+  return (
+    <Row>
+      <Col span={24}>
+        <DataTable
+          emptyLabel="No open orders"
+          dataSource={dataSource}
+          columns={columns}
+          pagination={true}
+        />
+      </Col>
+    </Row>
+  );
+}

--- a/src/components/UserInfoTable/InstructionTable.tsx
+++ b/src/components/UserInfoTable/InstructionTable.tsx
@@ -243,7 +243,7 @@ const columns = [
     key: 'status',
     render: (_, instruction: Instruction) => {
       if (instruction.trxError) {
-        return <Tag color={'danger'}>Error</Tag>
+        return <Tag color={'volcano'}>Error</Tag>
       } else {
         return <Tag color={'success'}>Success</Tag>
       }
@@ -276,6 +276,7 @@ export const InstructionTable:React.FC<{walletAddress: PublicKey}> = ({ walletAd
     account: publicKey,
   });
 
+  const receivingResult = (instructions.length > 0)
 
   const dataSource = (instructions || []).map((instruction, index) => ({
     ...instruction,
@@ -287,18 +288,16 @@ export const InstructionTable:React.FC<{walletAddress: PublicKey}> = ({ walletAd
     <Row>
       <Col span={24}>
         <DataTable
-          emptyLabel="No open orders"
+          emptyLabel="loading instructions"
           dataSource={dataSource}
           columns={columns}
           pagination={true}
-          loading={!isStreaming}
+          loading={isStreaming && !receivingResult}
         />
       </Col>
     </Row>
   );
 }
-
-
 
 export const InstructionTab = () => {
   const { wallet } = useWallet()

--- a/src/components/UserInfoTable/InstructionTable.tsx
+++ b/src/components/UserInfoTable/InstructionTable.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import DataTable from '../layout/DataTable';
 import { useWallet } from '../../utils/wallet';
-import { Col, Row, Tabs, Tag } from 'antd';
-import { Account, Instruction, useSerumInstruction } from './dfuse/use-serum-instruction';
+import { Col, Row, Tag } from 'antd';
+import { Account, Instruction, useSerumInstruction } from './dfuse/useSerumInstruction';
 import { MarketInfo } from '../../utils/types';
 import { MARKETS } from '@project-serum/serum';
-import { useBalances } from '../../utils/markets';
-import BalancesTable from './BalancesTable';
 import { PublicKey } from '@solana/web3.js';
 import Link from '../Link';
 
@@ -31,8 +29,8 @@ const TrxSignature:React.FC<{trxSignature: string}> = ({ trxSignature }) => {
 
 const resolveMarket = (marketAddress: string): string => {
   let marketName = marketAddress;
-  USE_MARKETS.map(market => {
-    if (market.address.toString() == marketAddress) {
+  USE_MARKETS.forEach(market => {
+    if (market.address.toString() === marketAddress) {
       marketName = market.name;
     }
   });
@@ -221,6 +219,10 @@ const columns = [
     dataIndex: 'market',
     key: 'market',
     render: (_, instruction: Instruction) => {
+      if (instruction.instruction.__typename === "UndecodedInstruction") {
+        return null
+      }
+
       if (instruction.instruction?.accounts?.market) {
         return resolveMarket(instruction.instruction.accounts.market.publicKey);
       }
@@ -236,11 +238,22 @@ const columns = [
     },
   },
   {
+    title: 'Status',
+    dataIndex: 'status',
+    key: 'status',
+    render: (_, instruction: Instruction) => {
+      if (instruction.trxError) {
+        return <Tag color={'danger'}>Error</Tag>
+      } else {
+        return <Tag color={'success'}>Success</Tag>
+      }
+    },
+  },
+  {
     title: 'Trx Signature',
     dataIndex: 'trxSignature',
     key: 'trxSignature',
     render: (_, instruction: Instruction) => {
-
       return <TrxSignature trxSignature={instruction.trxSignature} />
     },
   },
@@ -278,6 +291,7 @@ export const InstructionTable:React.FC<{walletAddress: PublicKey}> = ({ walletAd
           dataSource={dataSource}
           columns={columns}
           pagination={true}
+          loading={!isStreaming}
         />
       </Col>
     </Row>

--- a/src/components/UserInfoTable/InstructionTable.tsx
+++ b/src/components/UserInfoTable/InstructionTable.tsx
@@ -7,6 +7,8 @@ import { MarketInfo } from '../../utils/types';
 import { MARKETS } from '@project-serum/serum';
 import { useBalances } from '../../utils/markets';
 import BalancesTable from './BalancesTable';
+import { PublicKey } from '@solana/web3.js';
+import Link from '../Link';
 
 // Used in debugging, should be false in production
 const _IGNORE_DEPRECATED = false;
@@ -15,6 +17,17 @@ const USE_MARKETS: MarketInfo[] = _IGNORE_DEPRECATED
   ? MARKETS.map((m) => ({ ...m, deprecated: false }))
   : MARKETS;
 
+
+const TrxSignature:React.FC<{trxSignature: string}> = ({ trxSignature }) => {
+  return (
+    <Link
+      external
+      to={'https://explorer.solana.com/tx/' + trxSignature}
+    >
+      {trxSignature.slice(0, 8)}...{trxSignature.slice(trxSignature.length - 8)}
+    </Link>
+  )
+}
 
 const resolveMarket = (marketAddress: string): string => {
   let marketName = marketAddress;
@@ -221,7 +234,17 @@ const columns = [
     render: (_, instruction: Instruction) => {
       return renderInstructionDetails(instruction);
     },
-  }, {
+  },
+  {
+    title: 'Trx Signature',
+    dataIndex: 'trxSignature',
+    key: 'trxSignature',
+    render: (_, instruction: Instruction) => {
+
+      return <TrxSignature trxSignature={instruction.trxSignature} />
+    },
+  },
+  {
     title: 'Addresses',
     dataIndex: 'addresses',
     key: 'addresses',
@@ -231,10 +254,8 @@ const columns = [
     },
   }];
 
-export default function InstructionTable() {
-  let { wallet } = useWallet();
-
-  const publicKey = wallet.publicKey.toString();
+export const InstructionTable:React.FC<{walletAddress: PublicKey}> = ({ walletAddress }) =>{
+  const publicKey = walletAddress.toString();
   const {
     instructions,
     isStreaming,
@@ -268,7 +289,7 @@ export default function InstructionTable() {
 export const InstructionTab = () => {
   const { wallet } = useWallet()
   if(wallet && wallet.publicKey) {
-    return <InstructionTable />;
+    return <InstructionTable walletAddress={wallet.publicKey}/>;
   }
 
   return (

--- a/src/components/UserInfoTable/InstructionTable.tsx
+++ b/src/components/UserInfoTable/InstructionTable.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import DataTable from '../layout/DataTable';
 import { useWallet } from '../../utils/wallet';
-import { Col, Row, Tag } from 'antd';
+import { Col, Row, Tabs, Tag } from 'antd';
 import { Account, Instruction, useSerumInstruction } from './dfuse/use-serum-instruction';
 import { MarketInfo } from '../../utils/types';
 import { MARKETS } from '@project-serum/serum';
+import { useBalances } from '../../utils/markets';
+import BalancesTable from './BalancesTable';
 
 // Used in debugging, should be false in production
 const _IGNORE_DEPRECATED = false;
@@ -232,7 +234,6 @@ const columns = [
 export default function InstructionTable() {
   let { wallet } = useWallet();
 
-
   const publicKey = wallet.publicKey.toString();
   const {
     instructions,
@@ -261,3 +262,16 @@ export default function InstructionTable() {
     </Row>
   );
 }
+
+
+
+export const InstructionTab = () => {
+  const { wallet } = useWallet()
+  if(wallet && wallet.publicKey) {
+    return <InstructionTable />;
+  }
+
+  return (
+    <p>Connect a wallet to see your instruction history.</p>
+  )
+};

--- a/src/components/UserInfoTable/dfuse/gql.ts
+++ b/src/components/UserInfoTable/dfuse/gql.ts
@@ -2,8 +2,19 @@ export const streamSerumInstructionSubGraphql = `
 subscription($account: String!){
   serumInstructionHistory(account: $account){
     trxSignature
+    trxError
     instruction {
       __typename
+      
+      ...on UndecodedInstruction {
+        programIDIndex
+        accountCount
+        rawAccounts:accounts
+        dataLength
+        data
+        error
+      }
+      
       ...on  SerumNewOrder {
         side
         limitPrice

--- a/src/components/UserInfoTable/dfuse/gql.ts
+++ b/src/components/UserInfoTable/dfuse/gql.ts
@@ -1,6 +1,7 @@
 export const streamSerumInstructionSubGraphql = `
 subscription($account: String!){
   serumInstructionHistory(account: $account){
+    trxSignature
     instruction {
       __typename
       ...on  SerumNewOrder {

--- a/src/components/UserInfoTable/dfuse/gql.ts
+++ b/src/components/UserInfoTable/dfuse/gql.ts
@@ -1,0 +1,142 @@
+export const streamSerumInstructionSubGraphql = `
+subscription($account: String!){
+  serumInstructionHistory(account: $account){
+    instruction {
+      __typename
+      ...on  SerumNewOrder {
+        side
+        limitPrice
+        maxQuantity
+        orderType
+        clientID
+        accounts {
+          market {
+            ...AccountFragment
+          }
+          openOrders {
+            ...AccountFragment
+          }
+          requestQueue {
+            ...AccountFragment
+          }
+          payer {
+            ...AccountFragment
+          }
+          owner {
+            ...AccountFragment
+          }
+          coinVault {
+            ...AccountFragment
+          }
+          pcVault {
+            ...AccountFragment
+          }
+          splTokenProgram {
+            ...AccountFragment
+          }
+          rent {
+            ...AccountFragment
+          }
+          srmDiscount {
+            ...AccountFragment
+          }           
+        }
+      }
+      ...on SerumMatchOrder{
+        limit
+        accounts {
+          market {
+            ...AccountFragment
+          }
+          requestQueue {
+            ...AccountFragment
+          }
+          eventQueue {
+            ...AccountFragment
+          }
+          bids {
+            ...AccountFragment
+          }
+          asks {
+            ...AccountFragment
+          }
+          coinFeeReceivable {
+            ...AccountFragment
+          }
+          pcFeeReceivable {
+            ...AccountFragment
+          }
+        }
+      }
+      ...on SerumCancelOrder{
+        side
+        orderId
+        openOrders
+        openOrderSlot
+        accounts{
+          market {
+            ...AccountFragment
+          }
+          requestQueue {
+            ...AccountFragment
+          }
+          owner {
+            ...AccountFragment
+          }
+        }
+      }
+      ...on SerumSettleFunds {
+        __typename
+        accounts{
+          market {
+            ...AccountFragment
+          }
+          openOrders {
+            ...AccountFragment
+          }
+          owner {
+            ...AccountFragment
+          }
+          coinVault {
+            ...AccountFragment
+          }
+          pcVault {
+            ...AccountFragment
+          }
+          pcWallet {
+            ...AccountFragment
+          }
+          signer {
+            ...AccountFragment
+          }
+          splTokenProgram {
+            ...AccountFragment
+          }                    
+        }
+      }
+      ...on SerumCancelOrderByClientId{
+        clientID
+        accounts{
+          market {
+            ...AccountFragment
+          }
+          openOrders {
+            ...AccountFragment
+          }
+          requestQueue {
+            ...AccountFragment
+          }
+          owner {
+            ...AccountFragment
+          }
+        }
+      }
+    }
+  }
+}
+fragment AccountFragment on Account {
+  publicKey
+  isSigner
+  isWritable
+}`
+

--- a/src/components/UserInfoTable/dfuse/use-serum-instruction.tsx
+++ b/src/components/UserInfoTable/dfuse/use-serum-instruction.tsx
@@ -142,6 +142,7 @@ export interface CancelOrderByClientId {
 
 
 export interface Instruction {
+  trxSignature: string
   instruction: SerumInstruction
 }
 
@@ -199,7 +200,8 @@ const stringToGqlError = (input: string): GqlError => {
 
 const client = createDfuseClient({
   apiKey: 'web_0123456789abcdef',
-  network: 'mainnet.sol.dfuse.io',
+  // network: 'mainnet.sol.dfuse.io',
+  network: 'localhost:8080',
   authUrl: 'null://',
   secure: false,
   graphqlStreamClientOptions: {
@@ -223,7 +225,7 @@ export const useSerumInstruction = (
       account,
       onData: (data) => {
         setInstructions(prevState => {
-          return [...prevState, data];
+          return [data, ...prevState];
         });
       },
       onComplete: () => {

--- a/src/components/UserInfoTable/dfuse/use-serum-instruction.tsx
+++ b/src/components/UserInfoTable/dfuse/use-serum-instruction.tsx
@@ -200,8 +200,7 @@ const stringToGqlError = (input: string): GqlError => {
 
 const client = createDfuseClient({
   apiKey: 'web_0123456789abcdef',
-  // network: 'mainnet.sol.dfuse.io',
-  network: 'localhost:8080',
+  network: 'mainnet.sol.dfuse.io',
   authUrl: 'null://',
   secure: false,
   graphqlStreamClientOptions: {

--- a/src/components/UserInfoTable/dfuse/use-serum-instruction.tsx
+++ b/src/components/UserInfoTable/dfuse/use-serum-instruction.tsx
@@ -1,0 +1,256 @@
+import { useEffect, useState } from 'react';
+import { createDfuseClient, DfuseClient, Stream } from '@dfuse/client';
+import { streamSerumInstructionSubGraphql } from './gql';
+
+type SerumInstructionOptions = {
+  account: string
+}
+
+type UseSerumInstructionResponse = {
+  instructions: Instruction[]
+  isStreaming: boolean
+
+}
+export type SideType = 'BID' | 'ASK' | 'UNKNOWN'
+export type OrderType = 'LIMIT' | 'IMMEDIATE_OR_CANCEL' | 'POST_ONLY' | 'UNKNOWN'
+
+
+export interface Account {
+  publicKey: string
+  isWritable: boolean
+  isSigner: boolean
+}
+
+export type SerumInstruction =
+  | InitializeMarket
+  | NewOrder
+  | MatchOrder
+  | ConsumeEvents
+  | CancelOrder
+  | SettleFunds
+  | CancelOrderByClientId
+
+export interface InitializeMarket {
+  __typename: 'SerumInitializeMarket'
+  baseLotSize: number
+  quoteLotSize: number
+  feeRateBps: number
+  vaultSignerNonce: number
+  quoteDustThreshold: number
+
+  accounts: {
+    market: Account
+    splCoinToken: Account
+    splPriceToken: Account
+    coinMint: Account
+    priceMint: Account
+  }
+}
+
+export interface NewOrder {
+  __typename: 'SerumNewOrder'
+  side: SideType
+  limitPrice: number
+  maxQuantity: number
+  orderType: OrderType
+  clientID: number
+
+  accounts: {
+    market: Account
+    openOrders: Account
+    requestQueue: Account
+    payer: Account
+    owner: Account
+    coinVault: Account
+    pcVault: Account
+    splTokenProgram: Account
+    rent: Account
+    srmDiscount: Account | undefined
+  }
+}
+
+export interface MatchOrder {
+  __typename: 'SerumMatchOrder'
+  limit: number
+
+  accounts: {
+    market: Account
+    requestQueue: Account
+    eventQueue: Account
+    bids: Account
+    asks: Account
+    coinFeeReceivable: Account
+    pcFeeReceivable: Account
+  }
+}
+
+export interface ConsumeEvents {
+  __typename: 'SerumConsumeEvents'
+  limit: number
+
+  accounts: {
+    openOrders: Account[]
+    market: Account
+    eventQueue: Account
+    coinFeeReceivable: Account
+    pcFeeReceivable: Account
+  }
+}
+
+export interface CancelOrder {
+  __typename: 'SerumCancelOrder'
+  side: SideType
+  orderId: string
+  openOrders: string
+  openOrderSlot: number
+
+  accounts: {
+    market: Account
+    requestQueue: Account
+    owner: Account
+  }
+}
+
+export interface SettleFunds {
+  __typename: 'SerumSettleFunds'
+
+  accounts: {
+    market: Account
+    openOrders: Account
+    owner: Account
+    coinVault: Account
+    pcVault: Account
+    coinWallet: Account
+    pcWallet: Account
+    signer: Account
+    splTokenProgram: Account
+    referrerPCWallet: Account | undefined
+  }
+}
+
+export interface CancelOrderByClientId {
+  __typename: 'SerumCancelOrderByClientId'
+  clientID: number
+
+  accounts: {
+    market: Account
+    openOrders: Account
+    requestQueue: Account
+    owner: Account
+  }
+}
+
+
+export interface Instruction {
+  instruction: SerumInstruction
+}
+
+interface GqlError extends Error {
+  message: string
+  locations: unknown[]
+}
+
+const streamSerumInstructions = async (params: {
+  account: string;
+  onData: (data: Instruction) => void;
+  onError: (errs) => void;
+  onComplete: () => void;
+  client: DfuseClient,
+}): Promise<Stream> => {
+  const { account, onData, onError, client } = params;
+  let gqlErrors: GqlError[] = [];
+  const stateStream = await client.graphql<{ serumInstructionHistory: Instruction }>(
+    streamSerumInstructionSubGraphql,
+    (message) => {
+      if (message.type === 'error') {
+        gqlErrors = message.errors.map((error) => stringToGqlError(error.message));
+        onError(gqlErrors);
+      } else if (message.type === 'data') {
+        if (!message.data.serumInstructionHistory) {
+          onError([{ name: 'GqlError', message: 'Unknown Instruction', locations: [] }]);
+        } else {
+          onData(message.data.serumInstructionHistory);
+        }
+      }
+    },
+    {
+      variables: {
+        account,
+      },
+    },
+  );
+  return stateStream as Stream;
+};
+
+const stringToGqlError = (input: string): GqlError => {
+  const message = input;
+  const re = />:([^:]*:[^:]*)/;
+  const matches = input.match(re);
+  let locations: string[] = [];
+  if (matches) {
+    locations = matches[1].split(':');
+  }
+  return {
+    name: 'GqlError',
+    message,
+    locations,
+  };
+};
+
+const client = createDfuseClient({
+  apiKey: 'web_0123456789abcdef',
+  network: 'mainnet.sol.dfuse.io',
+  authUrl: 'null://',
+  secure: false,
+  graphqlStreamClientOptions: {
+    autoDisconnectSocket: false,
+  },
+});
+
+
+export const useSerumInstruction = (
+  params: SerumInstructionOptions,
+): UseSerumInstructionResponse => {
+  const { account } = params;
+  const [instructions, setInstructions] = useState<Instruction[]>([]);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [stream, setStream] = useState<Stream>();
+
+
+  const streamInstruction = async () => {
+    return streamSerumInstructions({
+      client,
+      account,
+      onData: (data) => {
+        setInstructions(prevState => {
+          return [...prevState, data];
+        });
+      },
+      onComplete: () => {
+      },
+      onError: (errs) => {
+      },
+    });
+  };
+
+
+  useEffect(() => {
+    streamInstruction().then((stream) => {
+      setIsStreaming(true);
+      setStream(stream);
+    });
+    return () => {
+      console.log('shutting down stream');
+      stream?.close();
+    };
+  }, [account]);
+
+  return {
+    instructions,
+    isStreaming,
+  };
+
+};
+
+export const wait = (ms: number) => new Promise(r => setTimeout(r, ms));
+

--- a/src/components/UserInfoTable/dfuse/useSerumInstruction.tsx
+++ b/src/components/UserInfoTable/dfuse/useSerumInstruction.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { createDfuseClient, DfuseClient, Stream } from '@dfuse/client';
 import { streamSerumInstructionSubGraphql } from './gql';
 
@@ -227,11 +227,9 @@ export const useSerumInstruction = (
   const { account } = params;
   const [instructions, setInstructions] = useState<Instruction[]>([]);
   const [isStreaming, setIsStreaming] = useState(false);
-  const [stream, setStream] = useState<Stream>();
   const [errors, setErrors] = useState<GqlError[]>([]);
 
-
-  const streamInstruction = async () => {
+  const streamInstructionCallback = useCallback(async () => {
     return streamSerumInstructions({
       client,
       account,
@@ -247,18 +245,18 @@ export const useSerumInstruction = (
         setErrors(errs)
       },
     });
-  };
-
+  }, [account]);
 
   useEffect(() => {
-    streamInstruction().then((stream) => {
+    let s: Stream
+    streamInstructionCallback().then((stream) => {
       setIsStreaming(true)
-      setStream(stream);
+      s = stream;
     });
     return () => {
-      stream?.close();
+      s?.close();
     };
-  }, [account]);
+  }, [account, streamInstructionCallback]);
 
   return {
     instructions,

--- a/src/components/UserInfoTable/index.jsx
+++ b/src/components/UserInfoTable/index.jsx
@@ -7,13 +7,11 @@ import FloatingElement from '../layout/FloatingElement';
 import FeesTable from './FeesTable';
 import { useOpenOrders, useBalances, useMarket } from '../../utils/markets';
 import { InstructionTab } from './InstructionTable';
-import { useWallet } from '../../utils/wallet';
 
 const { Paragraph } = Typography;
 const { TabPane } = Tabs;
 
 export default function Index() {
-  const { wallet } = useWallet();
   const { market } = useMarket();
   return (
     <FloatingElement style={{ flex: 1, paddingTop: 20 }}>

--- a/src/components/UserInfoTable/index.jsx
+++ b/src/components/UserInfoTable/index.jsx
@@ -6,7 +6,7 @@ import FillsTable from './FillsTable';
 import FloatingElement from '../layout/FloatingElement';
 import FeesTable from './FeesTable';
 import { useOpenOrders, useBalances, useMarket } from '../../utils/markets';
-import InstructionTable from './InstructionTable';
+import { InstructionTab } from './InstructionTable';
 import { useWallet } from '../../utils/wallet';
 
 const { Paragraph } = Typography;
@@ -42,11 +42,9 @@ export default function Index() {
             <FeesTable />
           </TabPane>
         ) : null}
-        {wallet && wallet.publicKey ? (
-          <TabPane tab="Serum Instructions" key="instructions">
-            <InstructionTable />
-          </TabPane>
-        ) : null}
+        <TabPane tab="Serum Instructions" key="instructions">
+          <InstructionTab />
+        </TabPane>
       </Tabs>
     </FloatingElement>
   );

--- a/src/components/UserInfoTable/index.jsx
+++ b/src/components/UserInfoTable/index.jsx
@@ -6,11 +6,14 @@ import FillsTable from './FillsTable';
 import FloatingElement from '../layout/FloatingElement';
 import FeesTable from './FeesTable';
 import { useOpenOrders, useBalances, useMarket } from '../../utils/markets';
+import InstructionTable from './InstructionTable';
+import { useWallet } from '../../utils/wallet';
 
 const { Paragraph } = Typography;
 const { TabPane } = Tabs;
 
 export default function Index() {
+  const { wallet } = useWallet();
   const { market } = useMarket();
   return (
     <FloatingElement style={{ flex: 1, paddingTop: 20 }}>
@@ -37,6 +40,11 @@ export default function Index() {
         {market && market.supportsSrmFeeDiscounts ? (
           <TabPane tab="Fee discounts" key="fees">
             <FeesTable />
+          </TabPane>
+        ) : null}
+        {wallet && wallet.publicKey ? (
+          <TabPane tab="Serum Instructions" key="instructions">
+            <InstructionTable />
           </TabPane>
         ) : null}
       </Tabs>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1283,6 +1283,14 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
+"@dfuse/client@^0.3.17":
+  version "0.3.17"
+  resolved "https://registry.yarnpkg.com/@dfuse/client/-/client-0.3.17.tgz#6d225394880f6e975783be7a8f7a6ebf2eae6842"
+  integrity sha512-GPF7SkqBXByF0sntScXZG0bo4j9iNGNl2UW1V9zwbx1oN8TFce+ewcp+u01QZGTxY0AVEXCVs94qWo3tjERkSA==
+  dependencies:
+    "@types/debug" "^0.0.31"
+    debug "^4.1.0"
+
 "@emotion/is-prop-valid@^0.8.8":
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
@@ -1810,6 +1818,11 @@
   integrity sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==
   dependencies:
     "@types/node" "*"
+
+"@types/debug@^0.0.31":
+  version "0.0.31"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-0.0.31.tgz#bac8d8aab6a823e91deb7f79083b2a35fa638f33"
+  integrity sha512-LS1MCPaQKqspg7FvexuhmDbWUhE2yIJ+4AgVIyObfc06/UKZ8REgxGNjZc82wPLWmbeOm7S+gSsLgo75TanG4A==
 
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"


### PR DESCRIPTION
Using dfuse's [serum instruction history stream ](http://mainnet.sol.dfuse.io/graphiql/), to populate a user's serum instruction history tab.